### PR TITLE
Test Actions context on PRs from forks

### DIFF
--- a/.github/workflows/02context.yaml
+++ b/.github/workflows/02context.yaml
@@ -1,5 +1,6 @@
 on:
   push:
+  pull_request:
 
 jobs:
   branch_for_tag:


### PR DESCRIPTION
Continuation of #44. To detect if `github.ref == 'refs/heads/master'` will be different when PR is `made` from `master` in forked repo.